### PR TITLE
Fix map resetting to lat 0, long 0 when data loading times out

### DIFF
--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -575,9 +575,8 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
           this.leafMap.fitBounds(bounds);
         }
       }
-      else {
-        this.leafMap.setView([0, 0], defaultZoom != null ? defaultZoom : 1);
-      }
+      // If bounds are invalid, keep current view position instead of
+      // resetting to [0, 0] (initial view is already set by setupMap)
     }
     this.render();
   }
@@ -598,12 +597,18 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
 
   onDataReceived(data) {
     log("onDataReceived");
+    const mapExisted = !!this.leafMap;
     this.setupMap();
 
     if (!data || data.length === 0 || (data.length !== 2 && data.length !== 3)) {
-      // No data or incorrect data, show a world map and abort
-      const defaultZoom = this.getConfiguredDefaultZoom();
-      this.leafMap.setView([0, 0], defaultZoom != null ? defaultZoom : 1);
+      // No data or incorrect data
+      if (!mapExisted) {
+        // First load with no data - show a world map
+        const defaultZoom = this.getConfiguredDefaultZoom();
+        this.leafMap.setView([0, 0], defaultZoom != null ? defaultZoom : 1);
+      }
+      // If the map already existed, keep current view position instead of
+      // resetting to [0, 0] (e.g. when a query times out on refresh)
       this.render();
       return;
     }


### PR DESCRIPTION
When a data query timed out or returned empty data on refresh, the map would unconditionally reset its view to [0, 0]. Now the map preserves its current view position when it already exists and new data is empty/invalid. The [0, 0] fallback is only used on initial map creation when no data is available yet.

https://claude.ai/code/session_016Rb72tbAZUdtQk4ZfSawoH