### PR TITLE
Calculate enclosing radius from centroid of all data points

### DIFF
--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -567,6 +567,13 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     if (hasHeadingValue(coord.heading)) {
       tooltipLines.push(`Heading: ${normalizeHeading(coord.heading).toFixed(1)}\u00b0`);
     }
+    const radius = this.calculateDataRadius();
+    if (radius != null) {
+      const nm = radius.radiusNM;
+      const m = radius.radiusMeters;
+      const metricStr = m < 1000 ? `${m.toFixed(0)} m` : `${(m / 1000).toFixed(2)} km`;
+      tooltipLines.push(`Data radius: ${parseFloat(nm.toPrecision(4))} nm (${metricStr})`);
+    }
     this.lastMarker.bindTooltip(tooltipLines.join('<br>'), {
       direction: 'top',
       offset: [0, -12],
@@ -638,6 +645,38 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     }
     this.updateLastMarker();
     this.zoomToFit();
+  }
+
+  calculateDataRadius() {
+    // Only use real data points (antimeridian midpoints lack lat_show/lon_show)
+    const realCoords = this.coords.filter(c => c.lat_show != null && c.lon_show != null);
+    if (realCoords.length === 0) {
+      return null;
+    }
+
+    // Compute geographic centroid (mean lat/lon)
+    let latSum = 0;
+    let lonSum = 0;
+    realCoords.forEach(c => {
+      latSum += c.lat_show;
+      lonSum += c.lon_show;
+    });
+    const center = L.latLng(latSum / realCoords.length, lonSum / realCoords.length);
+
+    // Find maximum distance from centroid to any data point
+    let radiusMeters = 0;
+    realCoords.forEach(c => {
+      const dist = center.distanceTo(c.position);
+      if (dist > radiusMeters) {
+        radiusMeters = dist;
+      }
+    });
+
+    return {
+      center,
+      radiusMeters,
+      radiusNM: radiusMeters / METERS_PER_NM,
+    };
   }
 
   zoomToFit(){


### PR DESCRIPTION
Add calculateDataRadius() which computes the geographic centroid (mean lat/lon) of all real data points and returns the maximum great-circle distance from that centroid to any point. This gives the smallest circle centred on the data's centroid that contains every data point.

The result (in nautical miles and metric) is surfaced in the last- position marker tooltip so operators can immediately see the spatial spread of the current track.

https://claude.ai/code/session_01SE8k5d5WMHin8vaVfbfKVA