### PR TITLE
Add Google Satellite and Google Satellite Hybrid map layers

### DIFF
--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -229,7 +229,17 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
         attribution: '&copy; Kort & Matrikelstyrelsen',
         tms: true,
         maxZoom: 18,
-      })
+      }),
+      'Google Satellite': L.tileLayer('https://mt{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+        attribution: '&copy; Google',
+        subdomains: ['0', '1', '2', '3'],
+        maxZoom: 21,
+      }),
+      'Google Satellite Hybrid': L.tileLayer('https://mt{s}.google.com/vt/lyrs=y&x={x}&y={y}&z={z}', {
+        attribution: '&copy; Google',
+        subdomains: ['0', '1', '2', '3'],
+        maxZoom: 21,
+      }),
     };
 
     this.timeSrv = $injector.get('timeSrv');


### PR DESCRIPTION
Adds two new tile layer options to the map layer selector:
- Google Satellite: pure satellite imagery (lyrs=s)
- Google Satellite Hybrid: satellite imagery with labels (lyrs=y)

Both layers use Google Maps tile servers (mt0-mt3) with maxZoom of 21.

https://claude.ai/code/session_019Lssc6ur3gXitcCBXBdYmh