### PR TITLE
Retry data fetch once when initial data is empty or invalid

### DIFF
--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -254,6 +254,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.lastMarker = null;
     this.last = null;
     this.setSizePromise = null;
+    this._dataRetried = false;
 
     // Panel events
     this.events.on('panel-initialized', this.onInitialized.bind(this));
@@ -730,12 +731,16 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.setupMap();
 
     if (!data || data.length === 0 || (data.length !== 2 && data.length !== 3)) {
-      // No data or incorrect data - keep current view position.
-      // setupMap already set the view to saved position or [0, 0] on first load,
-      // so no need to reset here (avoids jumping when data is still loading).
+      // No data or incorrect data - retry once after a short delay in case
+      // the data source wasn't ready yet (e.g. on initial page load).
+      if (!this._dataRetried) {
+        this._dataRetried = true;
+        this.$timeout(() => this.refresh(), 1000);
+      }
       this.render();
       return;
     }
+    this._dataRetried = false;
 
     // Asumption is that there are an equal number of properly matched timestamps
     // TODO: proper joining by timestamp?


### PR DESCRIPTION
On page load, the data source may not be ready yet, causing the panel to receive empty data. The map shows the correct saved view from localStorage but the last-position pointer is missing. This adds a single retry after 1 second to re-fetch data, avoiding infinite loops with a flag that resets on successful data receipt.

https://claude.ai/code/session_01SpEh5JyxjagBP6cJa8DNJa