### PR TITLE
Add persistent tooltips and tolerant lat/lon matching; bump version to 2.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-trackmap-panel",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "A plugin for Grafana that visualizes GPS points as a line on an interactive map.",
   "main": "src/module.js",
   "scripts": {

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -28,6 +28,8 @@
                     checked="ctrl.panel.showLayerChanger" on-change="ctrl.applyDefaultLayer()"></gf-form-switch>
     <gf-form-switch class="gf-form" label="Show last marker" label-class="width-11" tooltip="Show latest position marker (rotates with heading if available)"
                     checked="ctrl.panel.showLastMarker" on-change="ctrl.refreshLastMarker()"></gf-form-switch>
+    <gf-form-switch class="gf-form" label="Persistent tooltips" label-class="width-11" tooltip="Always show tooltips for the last and historic points. Disable to show tooltip only when hovering the last marker."
+                    checked="ctrl.panel.persistPointTooltips" on-change="ctrl.refreshLastMarker()"></gf-form-switch>
   </div>
   <div class="section gf-form-group">
     <h5 class="section-heading">Colors</h5>

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -33,8 +33,8 @@
       {"name": "Zoom in by selecting a range of points", "path": "img/topo-boxselect.jpg"},
       {"name": "Chose what map to display the data on", "path": "img/satellite-picker.jpg"}
     ],
-    "version": "2.1.4",
-    "updated": "2023-01-13"
+    "version": "2.1.9",
+    "updated": "2026-03-25"
   },
 
   "dependencies": {

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -24,13 +24,6 @@ function normalizeHeading(heading) {
   return ((heading % 360) + 360) % 360;
 }
 
-function headingMatchesTimestamp(headingPoint, targetTimestamp, toleranceMs = 1000) {
-  if (!headingPoint || headingPoint[0] == null || headingPoint[1] == null || targetTimestamp == null) {
-    return false;
-  }
-  return Math.abs(headingPoint[1] - targetTimestamp) <= toleranceMs;
-}
-
 function getNearestHeadingValue(headings, targetTimestamp, toleranceMs = 1000) {
   if (!headings || headings.length === 0 || targetTimestamp == null) {
     return null;
@@ -64,6 +57,95 @@ function getNearestHeadingValue(headings, targetTimestamp, toleranceMs = 1000) {
   });
 
   return bestDiff <= toleranceMs ? best : null;
+}
+
+
+function getNearestPoint(datapoints, targetTimestamp, toleranceMs = 1000) {
+  if (!datapoints || datapoints.length === 0 || targetTimestamp == null) {
+    return null;
+  }
+
+  let min = 0;
+  let max = datapoints.length - 1;
+
+  while (min <= max) {
+    const idx = Math.floor((min + max) / 2);
+    const ts = datapoints[idx][1];
+    if (ts === targetTimestamp) {
+      return { value: datapoints[idx][0], timestamp: ts, diff: 0 };
+    } else if (ts < targetTimestamp) {
+      min = idx + 1;
+    } else {
+      max = idx - 1;
+    }
+  }
+
+  let best = null;
+  let bestDiff = Infinity;
+  [max, min].forEach((idx) => {
+    if (idx >= 0 && idx < datapoints.length) {
+      const diff = Math.abs(datapoints[idx][1] - targetTimestamp);
+      if (diff < bestDiff) {
+        bestDiff = diff;
+        best = datapoints[idx];
+      }
+    }
+  });
+
+  if (!best || bestDiff > toleranceMs) {
+    return null;
+  }
+
+  return { value: best[0], timestamp: best[1], diff: bestDiff };
+}
+
+function normalizeDatapoints(datapoints) {
+  if (!datapoints || datapoints.length === 0) {
+    return [];
+  }
+
+  return datapoints
+    .filter((p) => p && p[0] != null && p[1] != null)
+    .slice()
+    .sort((a, b) => a[1] - b[1]);
+}
+
+function estimateSeriesStep(datapoints) {
+  if (!datapoints || datapoints.length < 2) {
+    return null;
+  }
+
+  const deltas = [];
+  for (let i = 1; i < datapoints.length; i++) {
+    const prevTs = datapoints[i - 1][1];
+    const curTs = datapoints[i][1];
+    if (prevTs != null && curTs != null) {
+      const delta = curTs - prevTs;
+      if (delta > 0 && isFinite(delta)) {
+        deltas.push(delta);
+      }
+    }
+  }
+
+  if (deltas.length === 0) {
+    return null;
+  }
+
+  deltas.sort((a, b) => a - b);
+  return deltas[Math.floor(deltas.length / 2)];
+}
+
+function getLatLonMatchTolerance(lats, lons) {
+  const latStep = estimateSeriesStep(lats);
+  const lonStep = estimateSeriesStep(lons);
+  const minStep = [latStep, lonStep].filter((x) => x != null).reduce((acc, x) => Math.min(acc, x), Infinity);
+  if (!isFinite(minStep)) {
+    return 1000;
+  }
+
+  // Allow for datasource jitter and bucket boundary differences between
+  // latitude and longitude query series.
+  return Math.max(1000, Math.floor(minStep * 1.5));
 }
 
 function getMapViewStorage() {
@@ -193,6 +275,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       defaultLayer: 'OpenStreetMap',
       showLayerChanger: true,
       showLastMarker: true,
+      persistPointTooltips: false,
       lineColor: 'red',
       pointColor: 'royalblue',
     });
@@ -252,6 +335,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.hoverTarget = null;
     this.hoverIndex = null;
     this.lastMarker = null;
+    this.historicTooltipMarkers = [];
     this.last = null;
     this.setSizePromise = null;
     this._dataRetried = false;
@@ -501,6 +585,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     if (this.leafMap) {
       this.polylines.forEach(p=>p.removeFrom(this.leafMap));
       this.removeLastMarker();
+      this.removeHistoricTooltipMarkers();
       this.onPanelClear();
       return;
     }
@@ -557,6 +642,31 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     }
   }
 
+  removeHistoricTooltipMarkers() {
+    this.historicTooltipMarkers.forEach((marker) => marker.removeFrom(this.leafMap));
+    this.historicTooltipMarkers = [];
+  }
+
+  makeTooltipContent(coord, title = 'Position') {
+    const lat = coord.lat_show != null ? coord.lat_show : coord.position.lat;
+    const lon = coord.lon_show != null ? coord.lon_show : coord.position.lng;
+    const lines = [
+      `<b>${title}</b>`,
+      `Lat: ${lat.toFixed(6)}`,
+      `Lon: ${lon.toFixed(6)}`,
+    ];
+
+    if (coord.timestamp != null && isFinite(coord.timestamp)) {
+      lines.push(`Time (UTC): ${moment.utc(coord.timestamp).format('YYYY-MM-DD HH:mm:ss')}`);
+      lines.push(`Time (Local): ${moment(coord.timestamp).format('YYYY-MM-DD HH:mm:ss')}`);
+    }
+    if (hasHeadingValue(coord.heading)) {
+      lines.push(`Heading: ${normalizeHeading(coord.heading).toFixed(1)}\u00b0`);
+    }
+
+    return lines.join('<br>');
+  }
+
   updateLastMarker() {
     this.removeLastMarker();
 
@@ -570,16 +680,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       zIndexOffset: 1000,
     }).addTo(this.leafMap);
 
-    const lat = coord.lat_show != null ? coord.lat_show : coord.position.lat;
-    const lon = coord.lon_show != null ? coord.lon_show : coord.position.lng;
-    let tooltipLines = [
-      `<b>Last Position</b>`,
-      `Lat: ${lat.toFixed(6)}`,
-      `Lon: ${lon.toFixed(6)}`,
-    ];
-    if (hasHeadingValue(coord.heading)) {
-      tooltipLines.push(`Heading: ${normalizeHeading(coord.heading).toFixed(1)}\u00b0`);
-    }
+    let tooltipLines = [this.makeTooltipContent(coord, 'Last Position')];
     const radius = this.calculateDataRadius();
     if (radius != null) {
       const nm = radius.radiusNM;
@@ -591,11 +692,50 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       direction: 'top',
       offset: [0, -12],
       className: 'trackmap-last-tooltip',
+      permanent: this.panel.persistPointTooltips,
     });
+  }
+
+  updateHistoricTooltipMarkers() {
+    this.removeHistoricTooltipMarkers();
+
+    if (!this.panel.persistPointTooltips || !this.coords || this.coords.length === 0) {
+      return;
+    }
+
+    for (let i = 0; i < this.coords.length; i++) {
+      if (i === this.last) {
+        continue;
+      }
+
+      const coord = this.coords[i];
+      if (!coord || coord.lat_show == null || coord.lon_show == null) {
+        continue;
+      }
+
+      const marker = L.circleMarker(coord.position, {
+        radius: 4,
+        color: this.panel.pointColor,
+        weight: 1,
+        fillColor: this.panel.pointColor,
+        fillOpacity: 0.9,
+        opacity: 1,
+      }).addTo(this.leafMap);
+
+      marker.bindTooltip(this.makeTooltipContent(coord, 'Historic Position'), {
+        direction: 'top',
+        className: 'trackmap-last-tooltip',
+        permanent: true,
+        opacity: 0.95,
+      });
+
+      this.historicTooltipMarkers.push(marker);
+    }
   }
 
   refreshLastMarker() {
     this.updateLastMarker();
+    this.updateHistoricTooltipMarkers();
     this.render();
   }
 
@@ -657,6 +797,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       );
     }
     this.updateLastMarker();
+    this.updateHistoricTooltipMarkers();
 
     // Reveal the map now that data and marker are in place
     const el = document.getElementById('trackmap-' + this.panel.id);
@@ -730,6 +871,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       this.hoverMarker.setIcon(makeDirectionIcon(this.panel.pointColor, this.coords[this.hoverIndex].heading, true));
     }
     this.updateLastMarker();
+    this.updateHistoricTooltipMarkers();
     this.render();
   }
 
@@ -755,19 +897,27 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.coords.length = 0;
     this.coordSlices.length = 0;
     this.coordSlices.push(0)
-    const lats = data[0].datapoints;
-    const lons = data[1].datapoints;
-    const headings = data.length === 3 ? data[2].datapoints.filter((p) => p && p[0] != null && p[1] != null) : null;
-    const pointCount = Math.min(lats.length, lons.length);
+    const lats = normalizeDatapoints(data[0].datapoints);
+    const lons = normalizeDatapoints(data[1].datapoints);
+    const headings = data.length === 3 ? normalizeDatapoints(data[2].datapoints) : null;
+    const lonToleranceMs = getLatLonMatchTolerance(lats, lons);
     this.last = null;
 
-    for (let i = 0; i < pointCount; i++) {
-      if (lats[i][0] == null || lons[i][0] == null ||
-          (lats[i][0] == 0 && lons[i][0] == 0) ||
-          lats[i][1] !== lons[i][1]) {
+    for (let i = 0; i < lats.length; i++) {
+      if (lats[i][0] == null || lats[i][1] == null) {
         continue;
       }
-      const pos = L.latLng(lats[i][0], lons[i][0])
+
+      const lonMatch = getNearestPoint(lons, lats[i][1], lonToleranceMs);
+      if (!lonMatch || lonMatch.value == null) {
+        continue;
+      }
+
+      if (lats[i][0] == 0 && lonMatch.value == 0) {
+        continue;
+      }
+
+      const pos = L.latLng(lats[i][0], lonMatch.value)
       let heading = headings ? getNearestHeadingValue(headings, lats[i][1]) : null;
 
       if (this.coords.length > 0){
@@ -793,7 +943,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
         position: pos,
         timestamp: lats[i][1],
         lat_show: lats[i][0],
-        lon_show: lons[i][0],
+        lon_show: lonMatch.value,
         heading: heading,
       });
       this.last = this.coords.length - 1;


### PR DESCRIPTION
### Motivation
- Provide an option to always show tooltips for the last and historic points to aid visual inspection of tracks. 
- Improve robustness of matching latitude/longitude/heading series by using tolerant timestamp matching and normalization to handle datasource jitter and missing/null datapoints. 
- Prepare plugin metadata for release by bumping the package/plugin versions and update timestamp. 

### Description
- Added a UI switch `persistPointTooltips` in `src/partials/options.html` and defaulted it to `false` in `trackmap_ctrl.js` to control permanent tooltips. 
- Implemented historic tooltip support by adding `historicTooltipMarkers`, `removeHistoricTooltipMarkers`, `makeTooltipContent`, `updateHistoricTooltipMarkers`, and integrated them into `updateLastMarker`, `refreshLastMarker`, `addDataToMap`, and `refreshColors`. 
- Replaced strict timestamp equality matching with helper functions `normalizeDatapoints`, `getNearestPoint`, `estimateSeriesStep`, and `getLatLonMatchTolerance` to find nearest matching lon/heading values within a tolerance and to ignore invalid datapoints; updated the main data processing loop accordingly in `trackmap_ctrl.js`. 
- Improved tooltip content formatting to include UTC/local times and normalized heading via `makeTooltipContent`. 
- Cleaned up map teardown by removing historic tooltip markers during `setupMap` teardown, and kept antimeridian handling and polyline slicing unchanged. 
- Bumped versions in `package.json` and `src/plugin.json` to `2.1.9` and updated the `updated` date in `src/plugin.json`. 

### Testing
- Executed the build with `npm run build` (invokes `grunt`) and the build completed successfully. 
- No automated unit tests were present or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43db18720832ab35495600d107814)