### PR TITLE
Add 'Always show tooltips' option for last and historical points

### DIFF
--- a/src/partials/module.css
+++ b/src/partials/module.css
@@ -14,3 +14,9 @@
   line-height: 1.5;
   white-space: nowrap;
 }
+
+.trackmap-history-tooltip {
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+}

--- a/src/partials/options.html
+++ b/src/partials/options.html
@@ -28,6 +28,8 @@
                     checked="ctrl.panel.showLayerChanger" on-change="ctrl.applyDefaultLayer()"></gf-form-switch>
     <gf-form-switch class="gf-form" label="Show last marker" label-class="width-11" tooltip="Show latest position marker (rotates with heading if available)"
                     checked="ctrl.panel.showLastMarker" on-change="ctrl.refreshLastMarker()"></gf-form-switch>
+    <gf-form-switch class="gf-form" label="Always show tooltips" label-class="width-11" tooltip="Keep tooltip visible and show tooltips for historical points"
+                    checked="ctrl.panel.showTooltipsAlways" on-change="ctrl.refreshLastMarker()"></gf-form-switch>
   </div>
   <div class="section gf-form-group">
     <h5 class="section-heading">Colors</h5>

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -282,6 +282,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       defaultLayer: 'OpenStreetMap',
       showLayerChanger: true,
       showLastMarker: true,
+      showTooltipsAlways: false,
       lineColor: 'red',
       pointColor: 'royalblue',
     });
@@ -341,6 +342,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.hoverTarget = null;
     this.hoverIndex = null;
     this.lastMarker = null;
+    this.historicTooltipMarkers = [];
     this.last = null;
     this.setSizePromise = null;
     this._dataRetried = false;
@@ -646,26 +648,21 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     }
   }
 
-  updateLastMarker() {
-    this.removeLastMarker();
+  removeHistoricTooltipMarkers() {
+    this.historicTooltipMarkers.forEach((marker) => marker.removeFrom(this.leafMap));
+    this.historicTooltipMarkers = [];
+  }
 
-    if (!this.panel.showLastMarker || this.last == null || !this.coords[this.last]) {
-      return;
-    }
-
-    const coord = this.coords[this.last];
-    this.lastMarker = L.marker(coord.position, {
-      icon: makeDirectionIcon(this.panel.pointColor, coord.heading, false),
-      zIndexOffset: 1000,
-    }).addTo(this.leafMap);
-
+  getPositionTooltipLines(coord, title = null) {
     const lat = coord.lat_show != null ? coord.lat_show : coord.position.lat;
     const lon = coord.lon_show != null ? coord.lon_show : coord.position.lng;
-    let tooltipLines = [
-      `<b>Last Position</b>`,
-      `Lat: ${lat.toFixed(6)}`,
-      `Lon: ${lon.toFixed(6)}`,
-    ];
+    const tooltipLines = [];
+    if (title) {
+      tooltipLines.push(`<b>${title}</b>`);
+    }
+    tooltipLines.push(`Lat: ${lat.toFixed(6)}`);
+    tooltipLines.push(`Lon: ${lon.toFixed(6)}`);
+
     if (coord.timestamp != null && isFinite(coord.timestamp)) {
       tooltipLines.push(`Time (UTC): ${moment.utc(coord.timestamp).format('YYYY-MM-DD HH:mm:ss')}`);
       tooltipLines.push(`Time (Local): ${moment(coord.timestamp).format('YYYY-MM-DD HH:mm:ss')}`);
@@ -673,18 +670,74 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     if (hasHeadingValue(coord.heading)) {
       tooltipLines.push(`Heading: ${normalizeHeading(coord.heading).toFixed(1)}\u00b0`);
     }
-    const radius = this.calculateDataRadius();
-    if (radius != null) {
-      const nm = radius.radiusNM;
-      const m = radius.radiusMeters;
-      const metricStr = m < 1000 ? `${m.toFixed(0)} m` : `${(m / 1000).toFixed(2)} km`;
-      tooltipLines.push(`Data radius: ${parseFloat(nm.toPrecision(4))} nm (${metricStr})`);
+
+    return tooltipLines;
+  }
+
+  updateHistoricTooltips() {
+    this.removeHistoricTooltipMarkers();
+
+    if (!this.panel.showTooltipsAlways || this.coords.length === 0) {
+      return;
     }
-    this.lastMarker.bindTooltip(tooltipLines.join('<br>'), {
-      direction: 'top',
-      offset: [0, -12],
-      className: 'trackmap-last-tooltip',
-    });
+
+    for (let i = 0; i < this.coords.length - 1; i++) {
+      const coord = this.coords[i];
+      if (coord.lat_show == null || coord.lon_show == null) {
+        continue;
+      }
+
+      const marker = L.circleMarker(coord.position, {
+        radius: 4,
+        color: this.panel.pointColor,
+        weight: 2,
+        fillColor: this.panel.pointColor,
+        fillOpacity: 0.75,
+        opacity: 0.9,
+      }).addTo(this.leafMap);
+
+      marker.bindTooltip(this.getPositionTooltipLines(coord).join('<br>'), {
+        direction: 'top',
+        offset: [0, -6],
+        className: 'trackmap-history-tooltip',
+        permanent: true,
+      });
+
+      this.historicTooltipMarkers.push(marker);
+    }
+  }
+
+  updateLastMarker() {
+    this.removeLastMarker();
+    this.removeHistoricTooltipMarkers();
+    if (this.panel.showLastMarker && this.last != null && this.coords[this.last]) {
+      const coord = this.coords[this.last];
+      this.lastMarker = L.marker(coord.position, {
+        icon: makeDirectionIcon(this.panel.pointColor, coord.heading, false),
+        zIndexOffset: 1000,
+      }).addTo(this.leafMap);
+
+      let tooltipLines = this.getPositionTooltipLines(coord, 'Last Position');
+      const radius = this.calculateDataRadius();
+      if (radius != null) {
+        const nm = radius.radiusNM;
+        const m = radius.radiusMeters;
+        const metricStr = m < 1000 ? `${m.toFixed(0)} m` : `${(m / 1000).toFixed(2)} km`;
+        tooltipLines.push(`Data radius: ${parseFloat(nm.toPrecision(4))} nm (${metricStr})`);
+      }
+      this.lastMarker.bindTooltip(tooltipLines.join('<br>'), {
+        direction: 'top',
+        offset: [0, -12],
+        className: 'trackmap-last-tooltip',
+        permanent: this.panel.showTooltipsAlways,
+      });
+
+      if (this.panel.showTooltipsAlways) {
+        this.lastMarker.openTooltip();
+      }
+    }
+
+    this.updateHistoricTooltips();
   }
 
   refreshLastMarker() {


### PR DESCRIPTION
### Motivation
- Provide a panel toggle that keeps the last-position tooltip visible instead of only showing it on hover. 
- When enabled, also show lightweight permanent tooltips for historical data points for easier inspection of past positions. 

### Description
- Added a new panel option `showTooltipsAlways` (default `false`) and an editor switch `Always show tooltips` in `src/partials/options.html`. 
- Introduced `getPositionTooltipLines`, `removeHistoricTooltipMarkers`, and `updateHistoricTooltips` helpers in `src/trackmap_ctrl.js` to centralize tooltip content and manage historic tooltip markers. 
- Render historic tooltips as `L.circleMarker` overlays with permanent tooltips (skipping synthetic antimeridian midpoints via the `lat_show`/`lon_show` checks) and keep the last-position marker tooltip permanently open when the option is enabled. 
- Added CSS rules for history tooltips in `src/partials/module.css` and refreshed historic tooltips when marker/color settings are refreshed. 

### Testing
- Ran `npm run build` which failed in this environment due to missing `grunt` (error: `sh: 1: grunt: not found`). 
- Ran `npm install` which failed due to registry access policy in this environment (`npm` returned `403 Forbidden`). 
- Verified code diffs and committed changes locally (`git` operations completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44f04ae58832aa9f93a292df65565)