### PR TITLE
Add permanent/historic tooltips toggle to TrackMap panel

### DIFF
--- a/src/partials/module.css
+++ b/src/partials/module.css
@@ -14,3 +14,30 @@
   line-height: 1.5;
   white-space: nowrap;
 }
+
+.trackmap-history-tooltip {
+  font-size: 11px;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.trackmap-tooltip-toggle {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.trackmap-tooltip-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  color: #222;
+  font-size: 12px;
+  font-weight: 600;
+  user-select: none;
+}
+
+.trackmap-tooltip-toggle-input {
+  margin: 0;
+}

--- a/src/trackmap_ctrl.js
+++ b/src/trackmap_ctrl.js
@@ -282,6 +282,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
       defaultLayer: 'OpenStreetMap',
       showLayerChanger: true,
       showLastMarker: true,
+      showTooltipsAlways: false,
       lineColor: 'red',
       pointColor: 'royalblue',
     });
@@ -341,6 +342,9 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.hoverTarget = null;
     this.hoverIndex = null;
     this.lastMarker = null;
+    this.historicTooltipMarkers = [];
+    this.tooltipToggleControl = null;
+    this.tooltipToggleInput = null;
     this.last = null;
     this.setSizePromise = null;
     this._dataRetried = false;
@@ -584,6 +588,45 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     this.addDataToMap();
   }
 
+  updateTooltipToggleControl() {
+    if (this.tooltipToggleInput) {
+      this.tooltipToggleInput.checked = Boolean(this.panel.showTooltipsAlways);
+      this.tooltipToggleInput.title = this.panel.showTooltipsAlways ? 'Permanent tooltips: ON' : 'Permanent tooltips: OFF';
+    }
+  }
+
+  addTooltipToggleControl() {
+    const ctrl = this;
+    const TooltipToggleControl = L.Control.extend({
+      options: { position: 'topright' },
+      onAdd(map) {
+        const container = L.DomUtil.create('div', 'leaflet-bar trackmap-tooltip-toggle');
+        const label = L.DomUtil.create('label', 'trackmap-tooltip-toggle-label', container);
+        const input = L.DomUtil.create('input', 'trackmap-tooltip-toggle-input', label);
+        input.type = 'checkbox';
+        input.checked = Boolean(ctrl.panel.showTooltipsAlways);
+
+        const text = L.DomUtil.create('span', 'trackmap-tooltip-toggle-text', label);
+        text.innerText = 'Tooltips';
+
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.disableScrollPropagation(container);
+        L.DomEvent.on(input, 'change', () => {
+          ctrl.panel.showTooltipsAlways = input.checked;
+          ctrl.refreshLastMarker();
+          ctrl.updateTooltipToggleControl();
+        });
+
+        ctrl.tooltipToggleInput = input;
+        ctrl.updateTooltipToggleControl();
+        return container;
+      },
+    });
+
+    this.tooltipToggleControl = new TooltipToggleControl();
+    this.leafMap.addControl(this.tooltipToggleControl);
+  }
+
   setupMap() {
     log("setupMap");
     // Create the map or get it back in a clean state if it already exists
@@ -631,6 +674,7 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
 
     // Scale control – nautical miles (top) and metric (bottom)
     makeScaleControl({ position: 'bottomleft', maxWidth: 150 }).addTo(this.leafMap);
+    this.addTooltipToggleControl();
 
     // Events
     this.leafMap.on('baselayerchange', this.mapBaseLayerChange.bind(this));
@@ -646,26 +690,21 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     }
   }
 
-  updateLastMarker() {
-    this.removeLastMarker();
+  removeHistoricTooltipMarkers() {
+    this.historicTooltipMarkers.forEach((marker) => marker.removeFrom(this.leafMap));
+    this.historicTooltipMarkers = [];
+  }
 
-    if (!this.panel.showLastMarker || this.last == null || !this.coords[this.last]) {
-      return;
-    }
-
-    const coord = this.coords[this.last];
-    this.lastMarker = L.marker(coord.position, {
-      icon: makeDirectionIcon(this.panel.pointColor, coord.heading, false),
-      zIndexOffset: 1000,
-    }).addTo(this.leafMap);
-
+  getPositionTooltipLines(coord, title = null) {
     const lat = coord.lat_show != null ? coord.lat_show : coord.position.lat;
     const lon = coord.lon_show != null ? coord.lon_show : coord.position.lng;
-    let tooltipLines = [
-      `<b>Last Position</b>`,
-      `Lat: ${lat.toFixed(6)}`,
-      `Lon: ${lon.toFixed(6)}`,
-    ];
+    const tooltipLines = [];
+    if (title) {
+      tooltipLines.push(`<b>${title}</b>`);
+    }
+    tooltipLines.push(`Lat: ${lat.toFixed(6)}`);
+    tooltipLines.push(`Lon: ${lon.toFixed(6)}`);
+
     if (coord.timestamp != null && isFinite(coord.timestamp)) {
       tooltipLines.push(`Time (UTC): ${moment.utc(coord.timestamp).format('YYYY-MM-DD HH:mm:ss')}`);
       tooltipLines.push(`Time (Local): ${moment(coord.timestamp).format('YYYY-MM-DD HH:mm:ss')}`);
@@ -673,22 +712,79 @@ export class TrackMapCtrl extends MetricsPanelCtrl {
     if (hasHeadingValue(coord.heading)) {
       tooltipLines.push(`Heading: ${normalizeHeading(coord.heading).toFixed(1)}\u00b0`);
     }
-    const radius = this.calculateDataRadius();
-    if (radius != null) {
-      const nm = radius.radiusNM;
-      const m = radius.radiusMeters;
-      const metricStr = m < 1000 ? `${m.toFixed(0)} m` : `${(m / 1000).toFixed(2)} km`;
-      tooltipLines.push(`Data radius: ${parseFloat(nm.toPrecision(4))} nm (${metricStr})`);
+
+    return tooltipLines;
+  }
+
+  updateHistoricTooltips() {
+    this.removeHistoricTooltipMarkers();
+
+    if (!this.panel.showTooltipsAlways || this.coords.length === 0) {
+      return;
     }
-    this.lastMarker.bindTooltip(tooltipLines.join('<br>'), {
-      direction: 'top',
-      offset: [0, -12],
-      className: 'trackmap-last-tooltip',
-    });
+
+    for (let i = 0; i < this.coords.length - 1; i++) {
+      const coord = this.coords[i];
+      if (coord.lat_show == null || coord.lon_show == null) {
+        continue;
+      }
+
+      const marker = L.circleMarker(coord.position, {
+        radius: 4,
+        color: this.panel.pointColor,
+        weight: 2,
+        fillColor: this.panel.pointColor,
+        fillOpacity: 0.75,
+        opacity: 0.9,
+      }).addTo(this.leafMap);
+
+      marker.bindTooltip(this.getPositionTooltipLines(coord).join('<br>'), {
+        direction: 'top',
+        offset: [0, -6],
+        className: 'trackmap-history-tooltip',
+        permanent: true,
+      });
+
+      this.historicTooltipMarkers.push(marker);
+    }
+  }
+
+  updateLastMarker() {
+    this.removeLastMarker();
+    this.removeHistoricTooltipMarkers();
+    if (this.panel.showLastMarker && this.last != null && this.coords[this.last]) {
+      const coord = this.coords[this.last];
+      this.lastMarker = L.marker(coord.position, {
+        icon: makeDirectionIcon(this.panel.pointColor, coord.heading, false),
+        zIndexOffset: 1000,
+      }).addTo(this.leafMap);
+
+      let tooltipLines = this.getPositionTooltipLines(coord, 'Last Position');
+      const radius = this.calculateDataRadius();
+      if (radius != null) {
+        const nm = radius.radiusNM;
+        const m = radius.radiusMeters;
+        const metricStr = m < 1000 ? `${m.toFixed(0)} m` : `${(m / 1000).toFixed(2)} km`;
+        tooltipLines.push(`Data radius: ${parseFloat(nm.toPrecision(4))} nm (${metricStr})`);
+      }
+      this.lastMarker.bindTooltip(tooltipLines.join('<br>'), {
+        direction: 'top',
+        offset: [0, -12],
+        className: 'trackmap-last-tooltip',
+        permanent: this.panel.showTooltipsAlways,
+      });
+
+      if (this.panel.showTooltipsAlways) {
+        this.lastMarker.openTooltip();
+      }
+    }
+
+    this.updateHistoricTooltips();
   }
 
   refreshLastMarker() {
     this.updateLastMarker();
+    this.updateTooltipToggleControl();
     this.render();
   }
 


### PR DESCRIPTION
### Motivation

- Provide an option to show permanent tooltips for the last position and historic points on the trackmap so users can more easily inspect coordinates and timestamps without hover interactions.
- Add a small UI control on the map to toggle permanent tooltips on/off for convenience.

### Description

- Added a new panel option `showTooltipsAlways` defaulting to `false` and corresponding CSS classes in `src/partials/module.css` for tooltip styling and the toggle control UI. 
- Implemented a Leaflet control via `addTooltipToggleControl` and `updateTooltipToggleControl` that renders a checkbox in the map `topright` and syncs with `this.panel.showTooltipsAlways`.
- Added marker management for historic/permanent tooltips with `historicTooltipMarkers`, `removeHistoricTooltipMarkers`, `getPositionTooltipLines`, and `updateHistoricTooltips`, and integrated these into `updateLastMarker` so the last marker and historic point labels are shown/hidden based on `showTooltipsAlways`.
- Hooked the tooltip toggle into map setup by calling `addTooltipToggleControl` from `setupMap`, and ensured `refreshLastMarker` updates the control state with `updateTooltipToggleControl`.

### Testing

- No automated tests were added or run for this change.
- Existing automated test suite results were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c44f04ae58832aa9f93a292df65565)